### PR TITLE
Finetuned IE 11 support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,8 +4,7 @@
       "targets": {
         "ie": "11"
       },
-      "useBuiltIns": "entry",
-      "debug": true
+      "useBuiltIns": "entry"
     }]
   ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,10 @@
  *
 */
 
+import '@babel/polyfill';
 import './barsPlus-directive';
 import props from './barsPlus-props';
 import { updateColorSchemas } from './colorSchemas';
-import '@babel/polyfill';
 
 export default {
   initialProperties: {


### PR DESCRIPTION
All ES6 features should work on IE11 now which is supported by babel polyfill. Also removed debug option.
Jira ticket: https://tretton37.atlassian.net/browse/QPE-547