### PR TITLE
Fix: Property affects wrong chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4410,12 +4410,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4430,17 +4432,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4557,7 +4562,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4569,6 +4575,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4583,6 +4590,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4590,12 +4598,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4614,6 +4624,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4694,7 +4705,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4706,6 +4718,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4827,6 +4840,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/barsPlus-props.js
+++ b/src/barsPlus-props.js
@@ -292,7 +292,7 @@ const definition ={
             return (data.props.orientation == "V" ? "X" : "Y") + "-Axis" + t;
           },
           items: {
-            LabelTitleD: {
+            labelTitleD: {
               type: "string",
               component: "dropdown",
               label: "Labels and title",
@@ -316,7 +316,7 @@ const definition ={
                   && (data.props.labelTitleD == 'B' || data.props.labelTitleD == 'T'));
               }
             },
-            LabelStyleD: {
+            labelStyleD: {
               type: "string",
               component: "dropdown",
               label: "Label style",
@@ -411,7 +411,7 @@ const definition ={
                   && (data.props.labelTitleM == 'B' || data.props.labelTitleM == 'T'));
               }
             },
-            LabelStyleM: {
+            labelStyleM: {
               type: "string",
               component: "dropdown",
               label: "Label style",

--- a/src/ldw-barsPlus.js
+++ b/src/ldw-barsPlus.js
@@ -1205,7 +1205,9 @@ export default {
         })
       ;
     }
-    d3.select('.ldw-d') //Dimension labels styling
+
+    d3.select(`#${this.id}`)
+      .select('.ldw-d') //Dimension labels styling
       .selectAll('.tick')
       .each(function(tick , i){
         if(g.labelStyleD === 'T'){
@@ -1228,8 +1230,8 @@ export default {
         }
       });
 
-
-    d3.select('.ldw-m') //Measures labels styling
+    d3.select(`#${this.id}`)
+      .select('.ldw-m') //Measures labels styling
       .selectAll('.tick')
       .each(function(tick , i){
         if(g.labelStyleM === 'T'){


### PR DESCRIPTION
-Changing the label style of a barPlus chart
 always only updated the first barPlus chart
 in the sheet, even if that chart isn't the
 one being edited.

-Problem was because d3 searched the whole sheet
 for the labels, instead of just the one belonging
 to the chart being edited.

Issue: DEB-115