### PR TITLE
NumericalAbbrevations and unrestricted min/max

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,6 @@ module.exports = {
   },
   rules: {
     "indent": ["error", 2, { "SwitchCase": 1 }],
-    "linebreak-style": ["error", "unix"],
     "object-curly-spacing": ["error", "always"],
     "max-lines": ["warn", 300],
     "max-len": ["warn", { "code": 120, "ignoreComments": true, "ignoreTrailingComments": false }],

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@
 import './barsPlus-directive';
 import props from './barsPlus-props';
 import { updateColorSchemas } from './colorSchemas';
+import { overrideD3FormatPrefix } from './numerical-abbrevation';
+import qlik from 'qlik';
 
 if (!window._babelPolyfill) { //eslint-disable-line no-underscore-dangle
   require('@babel/polyfill');
@@ -71,8 +73,12 @@ export default {
     exportData: true
   },
   template: '<bars-plus qv-extension />',
-  controller: ['$scope', function ($scope) {
-  }],
+  mounted: function () {
+    const app = qlik.currApp(this);
+    app.getAppLayout().then(function (res) {
+      overrideD3FormatPrefix(res.layout.qLocaleInfo.qNumericalAbbreviation);
+    });
+  },
   paint: function ($element, layout) {
     var self = this;
     self.$scope.g.self = self; // Save reference for call to backendApi

--- a/src/numerical-abbrevation.js
+++ b/src/numerical-abbrevation.js
@@ -1,0 +1,58 @@
+/*
+ Overrides the default prefixes (numerical abbrevations) used by D3 with the ones given by the
+ Qlik app.
+ */
+
+import d3 from 'd3';
+
+var overriddenAbbsStr = "";
+
+export function overrideD3FormatPrefix(qlikNumAbbsStr) {
+  if (!qlikNumAbbsStr || qlikNumAbbsStr === overriddenAbbsStr) {
+    return;
+  }
+
+  // Converts Qlik's NumericalAbbrevation string to dictionary where precision is key
+  let qlikNumAbbs = qlikNumAbbsStr.split(';');
+  const d3NumAbs = {
+    0: {
+      scale: function(d) { return d; },
+      symbol: ''
+    }
+  };
+  qlikNumAbbs.forEach(function (pairStr) {
+    let pair = pairStr.split(':');
+    if (pair.length != 2 || isNaN(pair[0])) {
+      return;
+    }
+
+    let precision = +pair[0];
+    let k = Math.pow(10, -precision);
+    d3NumAbs[precision] = {
+      scale: function(d) { return d * k; },
+      symbol: pair[1]
+    };
+  });
+
+
+  d3.formatPrefix = function (value, precision) {
+    if (!precision) {
+      // Need to determine the precision from the value
+      if (!value) {
+        return d3NumAbs[0];
+      }
+
+      let log10 = Math.floor(Math.log10(value));
+      let rest = log10 % 3;
+      precision = log10 - rest;
+    }
+
+    while (!(precision in d3NumAbs)) {
+      precision += precision < 0 ? 3 : -3;
+    }
+
+    return d3NumAbs[precision];
+  };
+
+  overriddenAbbsStr = qlikNumAbbsStr;
+}


### PR DESCRIPTION
-Converts the Qlik Numerical Abbrevations and
 overwrites d3's format to use them.

-Also, fixed the axes and bars so that they can
 show for any values and not just 0 to X where
 X is >= 1. Had to do this to make the numerical
 abbrevations for 10^-x work.

Issue: QLIK-93978, QLIK-93999