### PR TITLE
fix:QB-468 BAR&AREA chart extension went blank when maximize

### DIFF
--- a/src/ldw-barsPlus.js
+++ b/src/ldw-barsPlus.js
@@ -125,7 +125,7 @@ const ALIGN_HORIZONTAL_RIGHT = 'R';
 const ALIGN_VERTICAL_TOP = 'T';
 const ALIGN_VERTICAL_BOTTOM = 'B';
 
-// variables for bar
+// variables for bar extension
 let inThrottle;
 
 export default {

--- a/src/ldw-barsPlus.js
+++ b/src/ldw-barsPlus.js
@@ -125,6 +125,9 @@ const ALIGN_HORIZONTAL_RIGHT = 'R';
 const ALIGN_VERTICAL_TOP = 'T';
 const ALIGN_VERTICAL_BOTTOM = 'B';
 
+// variables for bar
+let inThrottle;
+
 export default {
 
   /**
@@ -1883,9 +1886,21 @@ export default {
  *--------------------------------------
  * Refresh chart, no new data
 */
-  refreshChart: function () {
-    this.initChart();
-    this.updateBars();
+  refreshChart: function refreshChart() {
+    try {
+      var refreshData = function() {
+        if (!inThrottle) {
+          inThrottle = true;
+          this.initChart();
+          this.updateBars();
+          setTimeout(() => inThrottle = false, 0);
+        }
+      };
+      refreshData.apply(this);
+    } catch(e) {
+      inThrottle = false;
+      throw e;
+    }
   },
   //--------------------------------------
   // Topological sort


### PR DESCRIPTION
Issue ::
[QB-468](https://jira.qlikdev.com/browse/QB-468)
File Changed ::
src/ldw-barsPlus.js
Code Changes ::
*added a variable to for throttling condition
*made changes in refresh chart method to support throttling


