### PR TITLE
fix: empty handle strings fixed

### DIFF
--- a/src/ldw-barsPlus.js
+++ b/src/ldw-barsPlus.js
@@ -254,6 +254,7 @@ export default {
       }
       p2 = c2;
     });
+    q = q.map(d=>d ===undefined? '': d);
     // Topological sort will throw an error if inconsistent data (sorting by measure)
     // Just ignore errors and use original sort order
     var qs, ps, rs = [];
@@ -272,8 +273,8 @@ export default {
     q = qs;
 
     var n = d3.nest()
-      .key(function (d) { return d[0].qText; })
-      .key(function (d) { return d[1].qText; })
+      .key(function (d) { return d[0].qText === undefined ? '' : d[0].qText; })
+      .key(function (d) { return d[1].qText === undefined ? '' : d[1].qText; })
       .entries(inData)
       ;
     // sort all nodes in order specified by q


### PR DESCRIPTION
This Pr is regarding bug QB-711, Bar & Area chart doesn't handle empty strings.
We have a solution, qText was not defined for empty strings and null value was not getting mapped. So we have added the following changes to handle undefined empty strings, in file ldw-barsPlus.js,

( fix the issue,  Chart is not rendered if first dimension is Flight_Quarter)
Line 257: q = q.map(d=>d ===undefined? '': d); 

(fix the issue , undefined" on the x-axis if the first dimension is FareClass )
Line 277: var n = d3.nest()
      .key(function (d) { return d[0].qText === undefined ? '' : d[0].qText; })
      .key(function (d) { return d[1].qText === undefined ? '' : d[1].qText; })
      .entries(inData)
      ;