### PR TITLE
chore: deprecate extension to april 1st

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,8 @@ gulp.task('qext', function () {
 		repository: pkg.repository,
 		dependencies: {
 			'qlik-sense': '>=5.5.x'
-		}
+		},
+    deprecated: '2021-04-01'
 	};
 	if (pkg.contributors) {
 		qext.contributors = pkg.contributors;


### PR DESCRIPTION
As the new barchart has almost the same features as the barplus, we've decided to deprecate it to the april release. There will be docs added in february for this.